### PR TITLE
fix detail

### DIFF
--- a/app/views/posts/_comments_cards.html.erb
+++ b/app/views/posts/_comments_cards.html.erb
@@ -1,4 +1,3 @@
-<h5>リクエスト一覧</h5>
 <div class="col s12">
   <div class="card">
     <div class="card-content">

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -53,10 +53,12 @@
   <% if user_signed_in? %>
     <% if @post.commented_by?(current_user) %>
       <div class="row">
+        <h5>リクエスト一覧</h5>
         <%= render partial: 'comments_cards', collection: @post.commented_by(current_user), as: :comment  %>
       </div>
     <% elsif current_user?(@post.user) %>
       <div class="row">
+        <h5>リクエスト一覧</h5>
         <%= render partial: 'comments_cards', collection: @post.comments, as: :comment %>
       </div>
     <% end %>

--- a/app/views/users/_users_cards.html.erb
+++ b/app/views/users/_users_cards.html.erb
@@ -8,7 +8,7 @@
             <%= image_tag user.user_icon, class: "icon_users" %>
             <div class="users_box">
               <span class="users_name"><%= user.name %></span>
-              <p class="users_area_text grey-text"><%= user.area %></p>
+              <p class="users_area_text grey-text"><%= user.area_i18n %></p>
             </div>
           </div>
           <% if current_user.followed_by?(user) %>

--- a/spec/system/comments_spec.rb
+++ b/spec/system/comments_spec.rb
@@ -13,8 +13,8 @@ RSpec.describe 'Comments', type: :system do
     find("#comments-form_#{post.id}").find('.comment-btn').click
   end
 
-  context '15文字以内でコメントが送られた時' do
-    it 'コメントを送るとコメント済みの画面にコメントした投稿とコメントが表示される', js: true do
+  context '15文字以内でコメントが送られた時', js: true do
+    it 'コメントを送るとコメント済みの画面にコメントした投稿とコメントが表示される' do
       fill_in 'comment[body]', with: '何それ行きた'
       expect do
         click_button 'commit'
@@ -26,8 +26,8 @@ RSpec.describe 'Comments', type: :system do
     end
   end
 
-  context '15文字より多い文字数のコメントが送られた時' do
-    it 'コメントを送ると元の画面がレンダリングされ、アラートが表示される', js: true do
+  context '15文字より多い文字数のコメントが送られた時', js: true do
+    it 'コメントを送ると元の画面がレンダリングされ、アラートが表示される' do
       fill_in 'comment[body]', with: '何何何何何何何何何何何何何何何何'
       expect do
         click_button 'commit'


### PR DESCRIPTION
- 「リクエスト一覧」が複数回表示されるようになっていたため修正
- ユーザー一覧のエリア表示を日本語に訂正